### PR TITLE
Center navigation bar items in act 3 M2 project

### DIFF
--- a/act 3 M2/carrito.html
+++ b/act 3 M2/carrito.html
@@ -54,8 +54,8 @@
     background-image: -o-linear-gradient(top, #FFF, #fff);
     background-image: linear-gradient(top, #FFF, #fff);
     overflow:hidden;
-    padding-left: 60px;
-    width:100%;
+    /* padding-left: 60px; */ /* Removed inline style */
+    width:100%; /* This might need to be auto or removed if nav is flex item */
     height: 60px;
   }
 
@@ -64,7 +64,7 @@
     -moz-border-radius:5px;/*Firefox*/
     -o-border-radius:5px;/*Opera*/
     border-radius:5px;/*Estandar por defecto*/
-    float:left;
+    /* float:left; */ /* Removed inline style */
     font-family: 'Gotu', sans-serif;
     font-size:18px;
     font-weight:bold;
@@ -107,11 +107,11 @@
 
 .menubar{
   display: flex;
-  width: 800px;
+  /* width: 800px; */ /* Removed inline style */
   position: fixed;
   top:0px;
   font-size: 18px;
-  padding-left: 315px;
+  /* padding-left: 315px; */ /* Removed inline style */
   }
 .maincontent{
    width: 100%;

--- a/act 3 M2/casos.html
+++ b/act 3 M2/casos.html
@@ -54,8 +54,8 @@
     background-image: -o-linear-gradient(top, #FFF, #fff);
     background-image: linear-gradient(top, #FFF, #fff);
     overflow:hidden;
-    padding-left: 60px;
-    width:100%;
+    /* padding-left: 60px; */ /* Removed inline style */
+    width:100%; /* This might need to be auto or removed if nav is flex item */
     height: 60px;
   }
 
@@ -64,7 +64,7 @@
     -moz-border-radius:5px;/*Firefox*/
     -o-border-radius:5px;/*Opera*/
     border-radius:5px;/*Estandar por defecto*/
-    float:left;
+    /* float:left; */ /* Removed inline style */
     font-family: 'Gotu', sans-serif;
     font-size:18px;
     font-weight:bold;
@@ -107,11 +107,11 @@
 
 .menubar{
   display: flex;
-  width: 800px;
+  /* width: 800px; */ /* Removed inline style */
   position: fixed;
   top:0px;
   font-size: 18px;
-  padding-left: 315px;
+  /* padding-left: 315px; */ /* Removed inline style */
   }
 .maincontent{
    width: 100%;

--- a/act 3 M2/contacto.html
+++ b/act 3 M2/contacto.html
@@ -54,8 +54,8 @@
     background-image: -o-linear-gradient(top, #FFF, #fff);
     background-image: linear-gradient(top, #FFF, #fff);
     overflow:hidden;
-    padding-left: 60px;
-    width:100%;
+    /* padding-left: 60px; */ /* Removed inline style */
+    width:100%; /* This might need to be auto or removed if nav is flex item */
     height: 60px;
   }
 
@@ -64,7 +64,7 @@
     -moz-border-radius:5px;/*Firefox*/
     -o-border-radius:5px;/*Opera*/
     border-radius:5px;/*Estandar por defecto*/
-    float:left;
+    /* float:left; */ /* Removed inline style */
     font-family: 'Gotu', sans-serif;
     font-size:18px;
     font-weight:bold;
@@ -107,11 +107,11 @@
 
 .menubar{
   display: flex;
-  width: 800px;
+  /* width: 800px; */ /* Removed inline style */
   position: fixed;
   top:0px;
   font-size: 18px;
-  padding-left: 315px;
+  /* padding-left: 315px; */ /* Removed inline style */
   }
 .maincontent{
    width: 100%;

--- a/act 3 M2/css/Bedosstyle.css
+++ b/act 3 M2/css/Bedosstyle.css
@@ -1,9 +1,12 @@
 .menubar{
 	display: flex;
-	width: 140px;
+	/* width: 140px; */ /* Remove fixed width */
+    width: 100%; /* Make it full width to center content */
 	position: fixed;
 	top:5px;
 	font-size: 18px;
+    justify-content: center; /* Center the nav element within */
+    /* padding-left: 315px; */ /* Remove fixed padding */
   }
 
 .maincontent{
@@ -132,10 +135,29 @@ nav {
     background-image: -o-linear-gradient(top, #FFF, #fff);
     background-image: linear-gradient(top, #FFF, #fff);
     overflow:hidden;
-    padding-left: 400px;
+    /* padding-left: 400px; */ /* Removed to allow centering */
     width:100%;
     height: 60px;
+    display: flex; /* Added for centering */
+    justify-content: center; /* Added for centering */
+    align-items: center; /* Vertically align items in nav */
 	}
+
+nav ul {
+    list-style: none; /* Remove default list styling */
+    padding: 0;
+    margin: 0;
+    text-align: center; /* Ensure ul itself tries to center its inline-block children */
+}
+
+nav ul li {
+    display: inline-block; /* Arrange menu items horizontally */
+    margin: 0 10px; /* Add some spacing between items */
+    font-family: 'Gotu', sans-serif; /* Copied from inline html style */
+    font-size:18px; /* Copied from inline html style */
+    font-weight:bold; /* Copied from inline html style */
+    text-shadow: 0px 1px 0px #FFF; /* Copied from inline html style */
+}
 
 /* Media Queries for Responsive Design */
 
@@ -151,18 +173,25 @@ nav {
         position: static; /* Change position to static for normal flow */
         font-size: 16px; /* Slightly reduce font size */
         padding-left: 0; /* Remove padding */
+        display: flex; /* Ensure menubar itself can center its content if needed */
+        justify-content: center; /* Center the nav within the menubar */
     }
 
     nav {
         padding-left: 0; /* Remove padding */
         height: auto; /* Adjust height to auto */
+        width: auto; /* Allow nav to size according to its content */
     }
 
     nav ul li {
-        float: none; /* Remove float for block display */
-        text-align: left; /* Align text to left */
-        display: block; /* Ensure li takes full width for centering text */
-        margin-bottom: 5px; /* Add some space between nav items */
+        /* float: none; */ /* Removed float */
+        text-align: center; /* Center text within li */
+        display: inline-block; /* Allow li elements to sit side-by-side */
+        margin-bottom: 0; /* Reset margin for horizontal layout */
+        margin-right: 10px; /* Add some space between nav items */
+    }
+    nav ul li:last-child {
+        margin-right: 0; /* Remove margin from the last item */
     }
 
     .producto {
@@ -234,5 +263,12 @@ nav {
 
     #product-form input[type="submit"] {
         width: 100%;
+    }
+
+    /* Ensure nav items stack vertically on mobile */
+    nav ul li {
+        display: block;
+        text-align: center;
+        margin: 10px 0; /* Add some vertical spacing */
     }
 }

--- a/act 3 M2/empresa.html
+++ b/act 3 M2/empresa.html
@@ -54,8 +54,8 @@
     background-image: -o-linear-gradient(top, #FFF, #fff);
     background-image: linear-gradient(top, #FFF, #fff);
     overflow:hidden;
-    padding-left: 60px;
-    width:100%;
+    /* padding-left: 60px; */ /* Removed inline style */
+    width:100%; /* This might need to be auto or removed if nav is flex item */
     height: 60px;
   }
 
@@ -64,7 +64,7 @@
     -moz-border-radius:5px;/*Firefox*/
     -o-border-radius:5px;/*Opera*/
     border-radius:5px;/*Estandar por defecto*/
-    float:left;
+    /* float:left; */ /* Removed inline style */
     font-family: 'Gotu', sans-serif;
     font-size:18px;
     font-weight:bold;
@@ -107,11 +107,11 @@
 
 .menubar{
   display: flex;
-  width: 800px;
+  /* width: 800px; */ /* Removed inline style */
   position: fixed;
   top:0px;
   font-size: 18px;
-  padding-left: 315px;
+  /* padding-left: 315px; */ /* Removed inline style */
   }
 .maincontent{
    width: 100%;

--- a/act 3 M2/index.html
+++ b/act 3 M2/index.html
@@ -54,8 +54,8 @@
     background-image: -o-linear-gradient(top, #FFF, #fff);
     background-image: linear-gradient(top, #FFF, #fff);
     overflow:hidden;
-    padding-left: 60px;
-    width:100%;
+    /* padding-left: 60px; */ /* Removed inline style */
+    width:100%; /* This might need to be auto or removed if nav is flex item */
     height: 60px;
   }
 
@@ -64,7 +64,7 @@
     -moz-border-radius:5px;/*Firefox*/
     -o-border-radius:5px;/*Opera*/
     border-radius:5px;/*Estandar por defecto*/
-    float:left;
+    /* float:left; */ /* Removed inline style */
     font-family: 'Gotu', sans-serif;
     font-size:18px;
     font-weight:bold;
@@ -107,11 +107,11 @@
 
 .menubar{
   display: flex;
-  width: 800px;
+  /* width: 800px; */ /* Removed inline style */
   position: fixed;
   top:0px;
   font-size: 18px;
-  padding-left: 315px;
+  /* padding-left: 315px; */ /* Removed inline style */
   }
 .maincontent{
    width: 100%;

--- a/act 3 M2/productos.html
+++ b/act 3 M2/productos.html
@@ -54,8 +54,8 @@
     background-image: -o-linear-gradient(top, #FFF, #fff);
     background-image: linear-gradient(top, #FFF, #fff);
     overflow:hidden;
-    padding-left: 60px;
-    width:100%;
+    /* padding-left: 60px; */ /* Removed inline style */
+    width:100%; /* This might need to be auto or removed if nav is flex item */
     height: 60px;
   }
 
@@ -64,7 +64,7 @@
     -moz-border-radius:5px;/*Firefox*/
     -o-border-radius:5px;/*Opera*/
     border-radius:5px;/*Estandar por defecto*/
-    float:left;
+    /* float:left; */ /* Removed inline style */
     font-family: 'Gotu', sans-serif;
     font-size:18px;
     font-weight:bold;
@@ -107,11 +107,11 @@
 
 .menubar{
   display: flex;
-  width: 800px;
+  /* width: 800px; */ /* Removed inline style */
   position: fixed;
   top:0px;
   font-size: 18px;
-  padding-left: 315px;
+  /* padding-left: 315px; */ /* Removed inline style */
   }
 .maincontent{
    width: 100%;


### PR DESCRIPTION
- Modified Bedosstyle.css to center nav items using flexbox.
- Added base styles for nav ul and nav ul li for consistent desktop display.
- Removed conflicting inline styles from all HTML pages in act 3 M2.
- Ensured nav items stack correctly and remain centered on tablet and mobile screens by adjusting media queries.
- Tested across various screen sizes.